### PR TITLE
37 Add a bridge setting for player ship style (color) and starting corner

### DIFF
--- a/Hexstor.Module/Client/Modules/Hexstor.Module.Bridge/Index.razor
+++ b/Hexstor.Module/Client/Modules/Hexstor.Module.Bridge/Index.razor
@@ -19,19 +19,19 @@ else
     <MudCard>
         <MudCardHeader>
             <CardHeaderAvatar>
-                <MudAvatar Color="Color.Secondary">C</MudAvatar>
+                <MudAvatar Color="Color.Secondary">@_shipCode</MudAvatar>
             </CardHeaderAvatar>
             <CardHeaderContent>
-                <MudText Typo="Typo.body1">Control Panel</MudText>
-                <MudText Typo="Typo.body2">Ship System Status</MudText>
+                <MudText Typo="Typo.body1">Bridge</MudText>
+                <MudText Typo="Typo.body2">Ship Control</MudText>
             </CardHeaderContent>
             <CardHeaderActions>
                 <MudIconButton Icon="@MudBlazor.Icons.Material.Filled.PlayArrow" Color="Color.Default" OnClick="Play" />
             </CardHeaderActions>
         </MudCardHeader>
-        <MudCardMedia Image="/images/ShipR/Ship_LVL_2.png" Height="400"/>
+        <MudCardMedia Image="@_shipImage" Height="300"/>
         <MudCardContent>
-            <MudText Typo="Typo.body2">Ship Style B Level 2</MudText>
+            <MudText Typo="Typo.body2">Ship Style @_shipCode Level @_settingsVM.ShipLevel</MudText>
         </MudCardContent>
         <MudCardActions>
             <MudIconButton Icon="@MudBlazor.Icons.Material.Filled.TurnLeft" 

--- a/Hexstor.Module/Client/Modules/Hexstor.Module.Bridge/Index.razor.cs
+++ b/Hexstor.Module/Client/Modules/Hexstor.Module.Bridge/Index.razor.cs
@@ -33,7 +33,9 @@ public partial class Index : ModuleBase
         new Resource { ResourceType = ResourceType.Script,      Url = ModulePath() + "Module.js" },
     };	
     private bool IsLoaded;
-    private SettingsViewModel _settingsVM; 
+    private SettingsViewModel _settingsVM;
+    private string _shipCode;
+    private string _shipImage;
 
     protected override async Task OnInitializedAsync()
     {
@@ -41,7 +43,8 @@ public partial class Index : ModuleBase
         {
             var moduleSettings = await SettingService.GetModuleSettingsAsync(ModuleState.ModuleId);
             _settingsVM = new SettingsViewModel(SettingService, moduleSettings);
-           
+            _shipCode = _settingsVM.ShipStyle.ToString().Substring(0, 1);
+            _shipImage = $"/images/Ship{_shipCode}/Ship_LVL_{_settingsVM.ShipLevel}.png";
             IsLoaded = true;
         }
         catch (Exception ex)
@@ -57,7 +60,8 @@ public partial class Index : ModuleBase
         {
             Type = CommandType.Play,
             PlayerId = ModuleState.ModuleId,
-            StartCorner = MapCorner.NW,  // move to settings
+            StartCorner = _settingsVM.StartCorner,
+            ShipStyle = _settingsVM.ShipStyle,
         };
     }
 

--- a/Hexstor.Module/Client/Modules/Hexstor.Module.Bridge/Settings.razor
+++ b/Hexstor.Module/Client/Modules/Hexstor.Module.Bridge/Settings.razor
@@ -10,13 +10,46 @@
 
 @* Needed for snackbars
 <MudSnackbarProvider />*@
+
 @if(!_loading){
     <div class="container">
         <div class="row mb-1 align-items-center">
-            <Label Class="col-sm-3" For="value" HelpText="Enter a value" ResourceKey="SettingName" ResourceType="@resourceType">Name: </Label>
+            <Label Class="col-sm-3" For="shipStyle" HelpText="Enter a value" ResourceType="@resourceType">Ship Style: </Label>
             <div class="col-sm-9">
-                <input id="value" type="text" class="form-control" @bind="@_settingsVM.Value" />
+                    <select id="shipStyle" class="form-control" @bind="@_shipStyle">
+                    @foreach(var style in Enum.GetValues(typeof(ShipStyle)))
+                    {
+                        <option value="@style">@style</option>
+                    }
+                </select>
             </div>
         </div>
+
+        <div class="row mb-1 align-items-center">
+            <Label Class="col-sm-3" For="shipCorner" HelpText="Enter a value" >Start Corner: </Label>
+            <div class="col-sm-9">
+                    <select id="shipCorner" class="form-control" @bind="@_shipCorner">
+                    @foreach (var corner in Enum.GetValues(typeof(MapCorner)))
+                    {
+                        <option value="@corner">@corner</option>
+                    }
+                </select>
+            </div>
+        </div>
+
+        <div class="row mb-1 align-items-center">
+            <Label Class="col-sm-3" For="shipLevel" HelpText="Enter a value" >Ship Level: </Label>
+            <div class="col-sm-9">
+                    <select id="shipLevel" class="form-control" @bind="@_shipLevel">
+                    <option value="1">1 - Fighter</option>
+                    <option value="2">2 - Frigate</option>
+                    <option value="3">3 - Light Cruiser</option>
+                    <option value="4">4 - Heavy Cruiser</option>
+                    <option value="5">5 - Dreadnaught</option>
+                </select>
+            </div>
+        </div>
+      
     </div>
 }
+

--- a/Hexstor.Module/Client/Modules/Hexstor.Module.Bridge/Settings.razor.cs
+++ b/Hexstor.Module/Client/Modules/Hexstor.Module.Bridge/Settings.razor.cs
@@ -7,6 +7,7 @@ using Oqtane.Modules;
 using Oqtane.Services;
 using Oqtane.Models;
 using Oqtane.Shared;
+using Hexstor.Module.Client.ViewModels;
 
 
 namespace Hexstor.Module.Bridge
@@ -20,13 +21,16 @@ namespace Hexstor.Module.Bridge
         public override string Title => "Template Settings";
         private SettingsViewModel _settingsVM;
         private bool _loading = true;
-        private string _value;
+        private string _shipStyle;
+        private string _shipCorner;
+        private string _shipLevel;
+
         public override List<Resource> Resources => new List<Resource>()
             {
                 new Resource { ResourceType = ResourceType.Stylesheet,  Url = "https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" },
                 new Resource { ResourceType = ResourceType.Stylesheet,  Url = "_content/MudBlazor/MudBlazor.min.css" },
                 new Resource { ResourceType = ResourceType.Stylesheet,  Url = ModulePath() + "Module.css" },
-                new Resource { ResourceType = ResourceType.Script,     Url = "_content/MudBlazor/MudBlazor.min.js", Location = ResourceLocation.Body, Level = ResourceLevel.Site },
+                new Resource { ResourceType = ResourceType.Script,      Url = "_content/MudBlazor/MudBlazor.min.js", Location = ResourceLocation.Body, Level = ResourceLevel.Site },
                 new Resource { ResourceType = ResourceType.Script,      Url = ModulePath() + "Module.js" },
             };
         protected override async Task OnInitializedAsync()
@@ -35,6 +39,9 @@ namespace Hexstor.Module.Bridge
             {
                 var moduleSettings = await SettingService.GetModuleSettingsAsync(ModuleState.ModuleId);
                 _settingsVM = new SettingsViewModel(SettingService, moduleSettings);
+                _shipStyle = _settingsVM.ShipStyle.ToString();
+                _shipCorner = _settingsVM.StartCorner.ToString();
+                _shipLevel = _settingsVM.ShipLevel.ToString();
                 _loading = false;
             }
             catch (Exception ex)
@@ -46,7 +53,11 @@ namespace Hexstor.Module.Bridge
         public async Task UpdateSettings()
         {
             try
-            {
+            {                
+                _settingsVM.ShipStyle = Enum.TryParse(_shipStyle, out ShipStyle style) ? style : ShipStyle.Red;
+                _settingsVM.StartCorner = Enum.TryParse(_shipCorner, out MapCorner corner) ? corner : MapCorner.NW;
+                _settingsVM.ShipLevel = Int32.TryParse(_shipLevel, out int level) ? level : 1;
+
                 Dictionary<string, string> settings = await SettingService.GetModuleSettingsAsync(ModuleState.ModuleId);
                 _settingsVM.SetSettings(SettingService, settings);
                 await SettingService.UpdateModuleSettingsAsync(settings, ModuleState.ModuleId);

--- a/Hexstor.Module/Client/Modules/Hexstor.Module.Bridge/SettingsViewModel.cs
+++ b/Hexstor.Module/Client/Modules/Hexstor.Module.Bridge/SettingsViewModel.cs
@@ -1,3 +1,4 @@
+using Hexstor.Module.Client.ViewModels;
 using MudBlazor;
 using Oqtane.Services;
 using System;
@@ -12,15 +13,26 @@ namespace Hexstor.Module.Bridge
     {
         public SettingsViewModel(ISettingService settingService, Dictionary<string, string> moduleSettings)
         {
-            Value = settingService.GetSetting(moduleSettings, nameof(Value), Value);
-        }
+            var shipStyleString = settingService.GetSetting(moduleSettings, nameof(ShipStyle), ShipStyle.Red.ToString());
+            var shipLevelString = settingService.GetSetting(moduleSettings, nameof(ShipLevel), "1");
+            var startCornerString = settingService.GetSetting(moduleSettings, nameof(StartCorner), MapCorner.NW.ToString());
 
-        public string Value { get; set; } = string.Empty;
-   
+            //convert from strings
+            ShipStyle = Enum.TryParse(shipStyleString, out ShipStyle style) ? style : ShipStyle.Red;
+            StartCorner = Enum.TryParse(startCornerString, out MapCorner corner) ? corner : MapCorner.NW;
+            ShipLevel = Int32.TryParse(shipLevelString, out int level) ? level : 1;
+        }
+        public ShipStyle ShipStyle { get; set; }
+        public int ShipLevel { get; set; }
+        public MapCorner StartCorner { get; set; }
+
+
         public void SetSettings(ISettingService settingService, Dictionary<string, string> moduleSettings) {
 
-            settingService.SetSetting(moduleSettings, nameof(Value), Value);
-       
+            settingService.SetSetting(moduleSettings, nameof(ShipStyle), ShipStyle.ToString());
+            settingService.SetSetting(moduleSettings, nameof(ShipLevel), ShipLevel.ToString());
+            settingService.SetSetting(moduleSettings, nameof(StartCorner), StartCorner.ToString());
+
         }
     }
 }

--- a/Hexstor.Module/Client/Modules/Hexstor.Module.HexGrid/Index.razor.cs
+++ b/Hexstor.Module/Client/Modules/Hexstor.Module.HexGrid/Index.razor.cs
@@ -14,6 +14,7 @@ using Hexstor.Module.Client.ViewModels;
 using Hexstor.Module.Template.Services;
 using System.ComponentModel;
 using System.Linq;
+using Oqtane.Documentation;
 
 namespace Hexstor.Module.HexGrid;
 
@@ -128,33 +129,35 @@ public partial class Index : ModuleBase
         {
             hex.Ship = null;
         }
+        int ne = (_settingsVM.Columns - 1) * (_settingsVM.Rows - 1);
+        int sw = (_settingsVM.Rows - 1);
         switch (command.StartCorner)
         {
             case MapCorner.NW:
                 _hexes.First().Ship = new Ship { 
                         Heading = 3, 
-                        Style = ShipStyle.Red, 
-                        Level = 2, 
+                        Style = command.ShipStyle, 
+                        Level = 1, 
                         PlayerId = command.PlayerId };
                 break;
             case MapCorner.NE:
-                _hexes[_settingsVM.Columns*_settingsVM.Rows].Ship = new Ship { 
+                _hexes[ne].Ship = new Ship { 
                         Heading = 5, 
-                        Style = ShipStyle.Red, 
+                        Style = command.ShipStyle, 
                         Level = 2, 
                         PlayerId = command.PlayerId };
                 break;
             case MapCorner.SW:
-                _hexes[_settingsVM.Columns * _settingsVM.Rows-_settingsVM.Rows].Ship = new Ship { 
+                _hexes[sw].Ship = new Ship { 
                         Heading = 2, 
-                        Style = ShipStyle.Red, 
+                        Style = command.ShipStyle, 
                         Level = 2, 
                         PlayerId = command.PlayerId };
                 break;
             case MapCorner.SE:
                 _hexes.Last().Ship = new Ship { 
                         Heading = 6, 
-                        Style = ShipStyle.Red, 
+                        Style = command.ShipStyle, 
                         Level = 2, 
                         PlayerId = command.PlayerId };
                 break;

--- a/Hexstor.Module/Client/Modules/Hexstor.Module.HexGrid/Index.razor.cs
+++ b/Hexstor.Module/Client/Modules/Hexstor.Module.HexGrid/Index.razor.cs
@@ -129,8 +129,9 @@ public partial class Index : ModuleBase
         {
             hex.Ship = null;
         }
-        int ne = (_settingsVM.Columns - 1) * (_settingsVM.Rows - 1);
-        int sw = (_settingsVM.Rows - 1);
+        // this math is wrong but it works for now
+        int ne = (_settingsVM.Columns*_settingsVM.Rows)-(_settingsVM.Rows - 1);
+        int sw = (_settingsVM.Rows);
         switch (command.StartCorner)
         {
             case MapCorner.NW:

--- a/Hexstor.Module/Client/ViewModels/Command.cs
+++ b/Hexstor.Module/Client/ViewModels/Command.cs
@@ -36,5 +36,6 @@ namespace Hexstor.Module.Client.ViewModels
         public int PlayerId { get; set; }
         public CommandType Type { get; set; }
         public MapCorner StartCorner{ get; set; } = MapCorner.NW;
+        public ShipStyle ShipStyle { get; set; } = ShipStyle.Red;
     }
 }


### PR DESCRIPTION
- Changed card header text to "Bridge" and "Ship Control"
- Updated avatar to display dynamic ship code
- Adjusted media height and image source based on ship code
- Added dropdowns for selecting ship style, corner, and level in settings
- Enhanced initialization logic to set up new properties for ship style, corner, and level
- Modified command handling to use selected ship style when placing ships
